### PR TITLE
Use absolute base URL for sandbox report storage

### DIFF
--- a/stanford/playground/master.yml
+++ b/stanford/playground/master.yml
@@ -8,6 +8,6 @@
     edxapp_theme_version: master
     EDXAPP_GRADE_STORAGE_KWARGS:
       location: /edx/var/edxapp/media/grades
-      base_url: /media/grades
+      base_url: "{{ EDXAPP_LMS_ROOT_URL }}/media/grades"
     # Remember to enable:
     # /admin/self_paced/selfpacedconfiguration/


### PR DESCRIPTION
Django default file storage expects an absolute URL for the base_url
argument to support the url() function. This fixes the issue of course
forums usage report 'Graph This' click not working.
@stvstnfrd 